### PR TITLE
Add params argument to "track" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ TwitterConvTrkr.init(init);
 
 Tracks the page a user is currently on.
 
-### `TwitterConvTrkr.track(action)`
+### `TwitterConvTrkr.track(action, params)`
 
 Tracks the action provided to function.
+
+The `params` argument is optional, and is used for when an action has required parameters. Please see [here](https://business.twitter.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites.html#advanced) for more information.
 
 > _YourTwitterConversionId_ is found in _twq('init','x3id')_ when you create the tailored audience.
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ var TwitterConvTrkr = {
     else console.error('TwitterConvTrkr init must be called first.');
   },
 
-  track: function(action) {
-    if (ConvId) twq('track', action);
+  track: function(action, params) {
+    if (ConvId) twq('track', action, params);
     else console.error('TwitterConvTrkr init must be called first.');
   }
 }


### PR DESCRIPTION
This is for when there are required arguments to a tracking event. See https://business.twitter.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites.html#advanced