### PR TITLE
Add types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 React JS component for [Twitter's conversion tracking.](https://business.twitter.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites.html)
 
 ** NOTE **
-This package is forked from [react-twitter-conversation-tracker](https://github.com/evankyle/react-twitter-conversion-tracker). The only addition to this
-package is the ability to [track any event](#twitterconvtrkrtrackaction).
+This package is forked from [react-twitter-conversation-tracker](https://github.com/evankyle/react-twitter-conversion-tracker) with the following new additions:
+- Ability to [track any event](#twitterconvtrkrtrackaction)
+- TypeScript type definitions
 
 ## Install
 ```

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "React JS component for Twitter's conversion tracking.",
   "main": "src/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for react-twitter-conversion-tracker-plus 1.1
+// Project: https://github.com/theworkflow/react-twitter-conversion-tracker
+// Definitions by: Coteh <https://github.com/Coteh>
+// Definitions: https://github.com/theworkflow/react-twitter-conversion-tracker
+
+declare module 'react-twitter-conversion-tracker-plus' {
+    export function init(convId: string): void;
+
+    export function pageView(): void;
+
+    export function track(action: string): void;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,10 +3,8 @@
 // Definitions by: Coteh <https://github.com/Coteh>
 // Definitions: https://github.com/theworkflow/react-twitter-conversion-tracker
 
-declare module 'react-twitter-conversion-tracker-plus' {
-    export function init(convId: string): void;
+export function init(convId: string): void;
 
-    export function pageView(): void;
+export function pageView(): void;
 
-    export function track(action: string): void;
-}
+export function track(action: string): void;

--- a/types/react-twitter-conversion-tracker-plus-tests.ts
+++ b/types/react-twitter-conversion-tracker-plus-tests.ts
@@ -1,4 +1,4 @@
-import TwitterConvTrkr from './index';
+import TwitterConvTrkr = require('./index');
 
 TwitterConvTrkr.init('nuqtg');
 

--- a/types/react-twitter-conversion-tracker-plus-tests.ts
+++ b/types/react-twitter-conversion-tracker-plus-tests.ts
@@ -1,4 +1,4 @@
-import TwitterConvTrkr from 'react-twitter-conversion-tracker-plus';
+import TwitterConvTrkr from './index';
 
 TwitterConvTrkr.init('nuqtg');
 

--- a/types/react-twitter-conversion-tracker-tests.ts
+++ b/types/react-twitter-conversion-tracker-tests.ts
@@ -1,0 +1,7 @@
+import TwitterConvTrkr from 'react-twitter-conversion-tracker-plus';
+
+TwitterConvTrkr.init('nuqtg');
+
+TwitterConvTrkr.pageView();
+
+TwitterConvTrkr.track('Search');

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "allowSyntheticDefaultImports": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-twitter-conversion-tracker-plus-tests.ts"
+    ]
+}


### PR DESCRIPTION
Add types so that this project can be used in TypeScript projects without having to add `@ts-ignore` to ignore the error for missing module types.